### PR TITLE
Remove the interactive flag from shell declaration

### DIFF
--- a/java/entrypoint.sh
+++ b/java/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -l
+#!/bin/sh
 
 mkdir -p "$2"
 java -cp /pklgen.jar org.pkl.codegen.java.Main "$1" -o "$2"

--- a/kotlin/entrypoint.sh
+++ b/kotlin/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -l
+#!/bin/sh
 
 mkdir -p "$2"
 java -cp /pklgen.jar org.pkl.codegen.kotlin.Main "$1" -o "$2"

--- a/swift/entrypoint.sh
+++ b/swift/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -l
+#!/bin/sh
 
 mkdir -p "$2"
 LD_LIBRARY_PATH=/usr/share/swift/usr/lib/swift/linux PATH=$PATH:/usr/share/swift/usr/bin/ /pkl-gen-swift "$1" -o "$2"


### PR DESCRIPTION
I don't know why it was there to begin with
